### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -36,7 +36,10 @@ def create_app(test_config=None):
         if path.startswith("api") or path.startswith("characters") or path.startswith("systems"):
             # Let API routes be handled by blueprints
             return ("", 404)
-        if path != "" and os.path.exists(os.path.join(app.static_folder, path)):
+        full_path = os.path.normpath(os.path.join(app.static_folder, path))
+        if not full_path.startswith(app.static_folder):
+            return ("", 404)
+        if path != "" and os.path.exists(full_path):
             return send_from_directory(app.static_folder, path)
         return send_from_directory(app.static_folder, "index.html")
 


### PR DESCRIPTION
Potential fix for [https://github.com/ajharris/AIGameMaster/security/code-scanning/2](https://github.com/ajharris/AIGameMaster/security/code-scanning/2)

To fix the issue, we need to validate the `path` variable to ensure it does not allow access to files outside the `static_folder`. This can be achieved by normalizing the path using `os.path.normpath` and verifying that the resulting path is within the `static_folder`. If the normalized path is not within the `static_folder`, we should return a 404 response.

Steps to implement the fix:
1. Normalize the `path` using `os.path.normpath`.
2. Construct the full path by joining the normalized `path` with `app.static_folder`.
3. Check if the full path starts with `app.static_folder`. If not, return a 404 response.
4. Use the validated full path in subsequent operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
