### PR TITLE
Potential fix for code scanning alert no. 393: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
Potential fix for [https://github.com/ajharris/AIGameMaster/security/code-scanning/393](https://github.com/ajharris/AIGameMaster/security/code-scanning/393)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Since the workflow primarily involves analyzing code using CodeQL, it likely only needs `contents: read` to access the repository's code. This change will ensure that the `GITHUB_TOKEN` has the least privilege necessary to perform the workflow tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
