### PR TITLE
Potential fix for code scanning alert no. 425: Information exposure through an exception

### DIFF
--- a/backend/routes/upload_rulebook.py
+++ b/backend/routes/upload_rulebook.py
@@ -117,4 +117,4 @@ def upload_rulebook():
             logging.error('File is empty')
         if 'encrypted' in msg or 'locked' in msg:
             return jsonify({'error': 'PDF is encrypted or locked'}), 400
-        return jsonify({'error': str(e)}), 400
+        return jsonify({'error': 'An internal error has occurred'}), 500


### PR DESCRIPTION
Potential fix for [https://github.com/ajharris/AIGameMaster/security/code-scanning/425](https://github.com/ajharris/AIGameMaster/security/code-scanning/425)

To fix the issue, we will replace the exposed exception details (`str(e)`) in the response with a generic error message. The detailed exception will still be logged internally using `logging.error(str(e))`, ensuring that developers have access to the information for debugging purposes. This change will prevent sensitive information from being exposed to external users.

Specifically:
1. Replace `return jsonify({'error': str(e)}), 400` with `return jsonify({'error': 'An internal error has occurred'}), 500`.
2. Ensure that the logging of the exception (`logging.error(str(e))`) remains intact for internal debugging purposes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
